### PR TITLE
add finger friendly in slider component.

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -2,10 +2,18 @@ import React, { Component, PropTypes } from 'react'
 import { View, PanResponder, Platform } from 'react-native'
 import Progress from './Progress'
 
+const FINGER_SIZE = 72;
+
 const theme = {
   base: {
     position: 'relative',
     marginVertical: 25,
+  },
+  finger: {
+    backgroundColor: 'rgba(0, 0, 0, 0)',
+    borderRadius: 90,
+    width: FINGER_SIZE,
+    height: FINGER_SIZE,
   },
   knob: {
     position: 'absolute',
@@ -19,6 +27,9 @@ const theme = {
     shadowOpacity: 0.25,
     shadowRadius: 4,
     shadowOffset: { width: 0, height: 2 },
+    alignItems: "center",
+    justifyContent: "center",
+
     // NOTE: for web
     ...(Platform.OS === 'web'
       ? {
@@ -102,10 +113,12 @@ class Slider extends Component {
     return (
       <View style={[theme.base, style, { width, height }]}>
         <Progress width={width} height={height} progress={progress} />
-        <View
-          {...this._panResponder.panHandlers}
-          style={[theme.knob, knobTransform, knobStyle]}
-        />
+          <View
+            {...this._panResponder.panHandlers}
+            style={[theme.knob, knobTransform, knobStyle]}
+          >
+            <View style={theme.finger} />
+          </View>
       </View>
     )
   }

--- a/src/__tests__/__snapshots__/Slider.spec.js.snap
+++ b/src/__tests__/__snapshots__/Slider.spec.js.snap
@@ -49,9 +49,11 @@ exports[`test should render correctly 1`] = `
     style={
       Array [
         Object {
+          "alignItems": "center",
           "backgroundColor": "white",
           "borderRadius": 22,
           "height": 44,
+          "justifyContent": "center",
           "left": -22,
           "position": "absolute",
           "shadowColor": "black",
@@ -73,6 +75,16 @@ exports[`test should render correctly 1`] = `
         },
         undefined,
       ]
-    } />
+    }>
+    <View
+      style={
+        Object {
+          "backgroundColor": "rgba(0, 0, 0, 0)",
+          "borderRadius": 90,
+          "height": 72,
+          "width": 72,
+        }
+      } />
+  </View>
 </View>
 `;


### PR DESCRIPTION
Improves the area of touch knob without changing the visual appearance
![captura de tela 2017-03-30 as 11 59 32](https://cloud.githubusercontent.com/assets/674449/24510740/6e809c9a-1540-11e7-829b-8065d3013ddf.png)

https://www.smashingmagazine.com/2012/02/finger-friendly-design-ideal-mobile-touchscreen-target-sizes/