### PR TITLE
readme: change tab to space to fix indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import { Button } from 'nachos-ui'
 
 const App = () => {
   return (
-  	<View>
+    <View>
     	<Button>Button</Button>
     </View>
   )


### PR DESCRIPTION
There was a tab that was causing the indentation to go weird on the first code shown in the docs. This fixes it.

![screenshot from 2017-04-10 16-35-39](https://cloud.githubusercontent.com/assets/7863230/24879030/d5546d56-1e0b-11e7-8580-977a28884bf3.png)
