### PR TITLE
Migrating React.PropTypes to PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "md5": "^2.2.1",
+    "prop-types": "^15.5.10",
     "query-string": "^4.3.1",
     "react": "15.x.x",
     "react-native": ">=0.40.0",

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { Text, View } from 'react-native'
 import themeManager from './themeManager'
 

--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { View, Text } from 'react-native'
 import themeManager from './themeManager'
 

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { View, Text, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import themeManager from './themeManager'

--- a/src/Card.js
+++ b/src/Card.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { View, Image } from 'react-native'
 import P from './typography/P'
 import themeManager from './themeManager'

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { View, TouchableOpacity, Platform } from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import themeManager from './themeManager'

--- a/src/Input.js
+++ b/src/Input.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { View, TextInput } from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import themeManager from './themeManager'

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { View } from 'react-native'
 import themeManager from './themeManager'
 

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Checkbox from './Checkbox'
 
 const Radio = (props) => {

--- a/src/RadioGroup.js
+++ b/src/RadioGroup.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { View, TouchableOpacity } from 'react-native'
 import Switcher from './Switcher'
 import Radio from './Radio'

--- a/src/SegmentedControlButton.js
+++ b/src/SegmentedControlButton.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Button from './Button'
 import themeManager from './themeManager'
 

--- a/src/TabButton.js
+++ b/src/TabButton.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import SegmentedControlButton from './SegmentedControlButton'
 import themeManager from './themeManager'
 

--- a/src/typography/Em.js
+++ b/src/typography/Em.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Text from './Text'
 import themeManager from '../themeManager'
 

--- a/src/typography/H1.js
+++ b/src/typography/H1.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Text from './Text'
 import themeManager from '../themeManager'
 

--- a/src/typography/H2.js
+++ b/src/typography/H2.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Text from './Text'
 import themeManager from '../themeManager'
 

--- a/src/typography/H3.js
+++ b/src/typography/H3.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Text from './Text'
 import themeManager from '../themeManager'
 

--- a/src/typography/H4.js
+++ b/src/typography/H4.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Text from './Text'
 import themeManager from '../themeManager'
 

--- a/src/typography/H5.js
+++ b/src/typography/H5.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Text from './Text'
 import themeManager from '../themeManager'
 

--- a/src/typography/H6.js
+++ b/src/typography/H6.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Text from './Text'
 import themeManager from '../themeManager'
 

--- a/src/typography/Strong.js
+++ b/src/typography/Strong.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Text from './Text'
 import themeManager from '../themeManager'
 

--- a/src/typography/Text.js
+++ b/src/typography/Text.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { Text as RNText } from 'react-native'
 
 import themeManager from '../themeManager'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2989,6 +2989,18 @@ fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.8:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.9:
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -4856,7 +4868,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -6305,6 +6317,13 @@ promise@7.1.1, promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 proxy-addr@~1.1.2:
   version "1.1.3"


### PR DESCRIPTION
Nachos-ui is raising warning during tests:
`Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs`
![image](https://user-images.githubusercontent.com/823150/29742493-ad1ab43c-8a56-11e7-86b4-e6c9a70b1f79.png)

Following documentation to migrate https://fb.me/prop-types-docs.